### PR TITLE
Allow CF_API_KEY on other server types e.g. PAPER, SPIGOT

### DIFF
--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -345,7 +345,7 @@ spec:
 {{- template "minecraft.envMap" list "QUERY_PORT" .Values.minecraftServer.query.port  }}
         {{- end }}
 
-    {{- if and .Values.minecraftServer.autoCurseForge (eq "AUTO_CURSEFORGE" .Values.minecraftServer.type) }}
+    {{- if .Values.minecraftServer.autoCurseForge }}
     {{- with .Values.minecraftServer.autoCurseForge }}
         - name: CF_API_KEY
           valueFrom:


### PR DESCRIPTION
Create CF_API_KEY resource on other server types to allow for CURSEFORGE_FILES auto download mods.

I'd like to use Curseforge auto downloader to download bukkit mods like: https://www.curseforge.com/minecraft/bukkit-plugins/worldedit

This works without needing to copy them out of mods folder. mc-image-helper knows to put them in plugins/ folder automatically.

Log Snippet
```
[mc-image-helper] 05:44:38.424 INFO  : Resolved paper to version 1.20.4 build 484
[init] Getting plugins via Spiget
[init] Downloading resource 18494 ...
[init] Resource '18494': installed version '1.27.0' already up to date
[mc-image-helper] 05:44:47.786 INFO  : Downloaded mod file plugins/worldedit-bukkit-7.3.0.jar
[mc-image-helper] 05:44:47.794 INFO  : Removing old file mods/worldedit-mod-7.3.0.jar
[init] server.properties already created and managed manually
```